### PR TITLE
Fix anamorphic macros when not in-package

### DIFF
--- a/lazylist.lisp
+++ b/lazylist.lisp
@@ -105,7 +105,8 @@
    The symbol SELF is bound to the start of the sequence, so can be
    used to define self-referential lazy sequences.
   "
-  `(self-ref self (lazy-list ,@items)))
+  (let ((self (intern (symbol-name 'self))))
+    `(self-ref ,self (lazy-list ,@items)))
 
 (defmacro alazy-list* (&rest items)
   "Anamorphic macro which creates a lazy list consisting
@@ -120,7 +121,8 @@
    (take 10 (alazy-list* 1 (maps #'1+ self)))
    => '(1 2 3 4 5 6 7 8 9 10))
   "
-  `(self-ref self (lazy-list* ,@items)))
+  (let ((self (intern (symbol-name 'self))))
+    `(self-ref ,self (lazy-list* ,@items))))
 
 (example
  (take 10 (alazy-list* 1 (maps #'1+ self)))


### PR DESCRIPTION
Sorry, only tested previously when in-package.

Symbol SELF interned in LAZYSEQ package, so anamorphic macros alazy-list and alazy-list* only
worked if used within LAZYSEQ.

This patch interns SELF at macroexpansion time, so works if used package-qualified or imported (use'd).

