### PR TITLE
Support for array sequences, and lazy sorting

### DIFF
--- a/lazylist.lisp
+++ b/lazylist.lisp
@@ -11,7 +11,7 @@
 
 (defmacro lazy-list (&rest items)
   "Construct a lazy sequence from given ITEMS.
-   These will be evaluated lazily."
+These will be evaluated lazily."
   (let ((inner nil))
     (dolist (it (reverse items))
       (setf inner `(lazy-seq (cons ,it ,inner))))
@@ -32,9 +32,8 @@
 
 (defmacro lazy-list* (&rest items)
   "Construct a lazy sequence from given ITEMS.
-   These will be evaluated lazily. 
-   The last element of ITEMS is expected to be a
-   lazy sequence or list."
+These will be evaluated lazily. 
+The last element of ITEMS is expected to be a lazy sequence or list."
   (let* ((items-rev (reverse items))
          (inner (first items-rev)))
     (dolist (it (rest items-rev))
@@ -77,14 +76,14 @@
 
 (defmacro self-ref (sym items)
   "Binds a symbol SYM to refer to the lazy sequence or list ITEMS.
-   SYM is bound to a lazy-ref-cell in the evaluation of ITEMS
-   so can be used to create self-referential lazy lists
+SYM is bound to a lazy-ref-cell in the evaluation of ITEMS
+so can be used to create self-referential lazy lists
 
-   Example:  The Fibonacci sequence
+Example:  The Fibonacci sequence
 
-   (take 10
-      (self-ref fib (lazy-list* 1 1 (maps #'+ fib (tail fib)))))
-   => '(1 1 2 3 5 8 13 21 34 55))
+(take 10
+  (self-ref fib (lazy-list* 1 1 (maps #'+ fib (tail fib)))))
+ => '(1 1 2 3 5 8 13 21 34 55))
 
   "
   `(let ((,sym (make-lazy-ref-cell)))
@@ -99,17 +98,17 @@
  => '(1 1 2 3 5 8 13 21 34 55))
 
 (defmacro alazy-list (&rest items)
-  "Anamorphic macro which creates a lazy list consisting
+  "Anaphoric macro which creates a lazy list consisting
    of the given ITEMS, which will be evaluated lazily.
 
    The symbol SELF is bound to the start of the sequence, so can be
    used to define self-referential lazy sequences.
   "
-  (let ((self (intern (symbol-name 'self))))
+  (let ((self (intern (symbol-name 'self)))) ; intern so that SELF does not need to be exported
     `(self-ref ,self (lazy-list ,@items)))
 
 (defmacro alazy-list* (&rest items)
-  "Anamorphic macro which creates a lazy list consisting
+  "Anaphoric macro which creates a lazy list consisting
    of the given ITEMS, which will be evaluated lazily. 
    The final item in ITEMS is expected to be a list or lazy sequence.
 
@@ -121,7 +120,7 @@
    (take 10 (alazy-list* 1 (maps #'1+ self)))
    => '(1 2 3 4 5 6 7 8 9 10))
   "
-  (let ((self (intern (symbol-name 'self))))
+  (let ((self (intern (symbol-name 'self)))) ; intern so that SELF does not need to be exported
     `(self-ref ,self (lazy-list* ,@items))))
 
 (example

--- a/lazylist.lisp
+++ b/lazylist.lisp
@@ -105,7 +105,7 @@ Example:  The Fibonacci sequence
    used to define self-referential lazy sequences.
   "
   (let ((self (intern (symbol-name 'self)))) ; intern so that SELF does not need to be exported
-    `(self-ref ,self (lazy-list ,@items)))
+    `(self-ref ,self (lazy-list ,@items))))
 
 (defmacro alazy-list* (&rest items)
   "Anaphoric macro which creates a lazy list consisting

--- a/lazyseq.asd
+++ b/lazyseq.asd
@@ -17,6 +17,7 @@
                (:file "xform")
                (:file "reduce")
                (:file "lazylist")
+               (:file "lazysort")
                ))
 
 (defmethod perform ((o asdf:test-op) (c (eql (find-system :lazyseq))))

--- a/lazyseq.lisp
+++ b/lazyseq.lisp
@@ -116,6 +116,15 @@ satisfying the predicate PRED."
  (take-while (lambda (x) (< x 10)) (nats 1))
  => '(1 2 3 4 5 6 7 8 9))
 
+(defun take-all (s)
+  "Returns the list of all elements of the sequence S.
+
+CAUTION: This will never return if given an infinite sequence."
+  (loop
+     for cell = s then (tail cell)
+     when (not cell) do (return result)
+     collecting (head cell) into result))
+
 
 (defun drop (n s)
   "Drops the first N elements of sequence S."

--- a/lazyseq.lisp
+++ b/lazyseq.lisp
@@ -7,16 +7,55 @@
 (defmethod head ((c list))
   (first c))
 
+(defmethod head ((c array))
+  (row-major-aref c 0))
+
+(example
+ (head '(:a :b :c))
+ => :a)
+
+(example
+ (head "hello")
+ => #\h)
+
+(example
+ (head #(1 2 3))
+ => 1)
+
+(example
+ (head #2A((4 3) (2 1)))
+ => 4)
+
 (defgeneric tail (sequence)
   (:documentation "Taking the tail of SEQUENCE."))
 
 (defmethod tail ((c list))
   (rest c))
 
+(defmethod tail ((c array))
+  "Return a flattened array, displaced to C. 
+This avoids copying data."
+  (make-array (1- (array-total-size c))
+              :displaced-to c
+              :displaced-index-offset 1
+              :element-type (array-element-type c)))
+
+(example
+ (tail "hello")
+ => "ello")
+
+(let ((*example-equal-predicate* #'equalp))
+  (example
+   (tail #2A((4 3) (2 1)))
+   => #(3 2 1))) ; note array flattened, displaced
+
 (defgeneric print-cell (c out)
   (:documentation "Priting cell C to OUT."))
 
 (defmethod print-cell ((c list) out)
+  (format out "~{~a~^ ~}" c))
+
+(defmethod print-cell ((c array) out)
   (format out "~{~a~^ ~}" c))
 
 (defstruct lazy-cell

--- a/lazysort.lisp
+++ b/lazysort.lisp
@@ -1,0 +1,78 @@
+(in-package #:lazyseq)
+
+(defun lazy-sort-next (ls pred remainder)
+  "Lazily sort list LS so that the next element is at the front. 
+Predicate PRED should return non-NIL if ARG1 is to precede ARG2.
+
+Note: The result is a mix of cons cells and lazy-seq cells
+  "
+  (let ((pivot (first ls))
+        before-pivot
+        after-pivot)
+    (dolist (elem (rest ls))
+      (if (funcall pred elem pivot)
+          (push elem before-pivot)
+          (push elem after-pivot)))
+    ;; Now have partitioned into [before-pivot : pivot : after-pivot]
+    (if (not before-pivot)
+        (if (not after-pivot)
+            (cons pivot remainder) ; ( (a) rem ) => (cons a rem)
+            (cons pivot
+                  (lazy-seq
+                   (lazy-sort-next
+                    after-pivot pred remainder)))) ; ( (a b) rem ) => (cons a (sort b rem))
+        
+        ;; Partially sorted, but before-pivot not empty.
+        ;; Keep sorting to find the first element
+        (if (not after-pivot)
+            ;; pivot is the last element
+            (lazy-sort-next before-pivot pred (cons pivot remainder)) ; ( (b a) rem ) => (sort b (cons a rem))
+            ;; Have elements before and after pivot: ( (b a c) rem) => (sort b (cons a (sort c)))
+            (lazy-sort-next before-pivot pred (cons pivot
+                                                    (lazy-seq
+                                                     (lazy-sort-next
+                                                      after-pivot pred remainder))))))))
+
+        
+(defun lazy-sort (s pred)
+  "Lazily sort sequence S using the Quicksort algorithm. 
+Predicate PRED should return non-NIL if ARG1 is to precede ARG2.
+
+The result is a mix of cons cells and lazy-seq cells. Only the part
+of the result which is needed is sorted completely. This can be faster
+than SORT if only a small number of elements is needed.
+
+CAUTION: This forces evaluation of the whole sequence S, so
+will not return if given an infinite sequence.
+
+Idea from Clojure code by Ben Ashford: 
+http://benashford.github.io/blog/2014/03/22/the-power-of-lazy-sequences/
+"
+  ;; Start sorting, ensuring that S is a list
+  (when s ; Catch the empty list case
+    (lazy-seq (lazy-sort-next (take-all s) pred nil))))
+
+(example
+ (take-all (lazy-sort nil #'>))
+ => nil)
+
+(example
+ (take 10 (lazy-sort '(1) #'>))
+ => '(1))
+
+(example
+ (take 10 (lazy-sort '(1 2) #'<))
+ => '(1 2))
+
+(example
+ (take 10 (lazy-sort '(1 2) #'>))
+ => '(2 1))
+
+(example
+ (take 10 (lazy-sort '(2 1 3) #'>))
+ => '(3 2 1))
+
+(example
+ (take 10 (lazy-sort '(5 4 3 2 1 6 7 8 9) #'<))
+ => '(1 2 3 4 5 6 7 8 9))
+

--- a/packages.lisp
+++ b/packages.lisp
@@ -26,6 +26,7 @@
    #:lazy-seq
    #:take
    #:take-while
+   #:take-all
    #:drop
    #:drop-while
    #:seq-elt
@@ -59,6 +60,8 @@
    #:line-seq
    #:string-line-seq
    #:file-line-seq
+   ;; Sorting
+   #:lazy-sort
    ))
 
 

--- a/reduce.lisp
+++ b/reduce.lisp
@@ -55,7 +55,7 @@ CAUTION: This may never return if applied to an infinite sequence"
 
 (defun all (f s)
   "Returns T if unary function F returns true for all of sequence S.
-CAUTION: This will never return if applied to an infinite sequence"
+CAUTION: This may never return if applied to an infinite sequence"
   (if s
       (loop
          for cell = s then (tail cell)


### PR DESCRIPTION
* Adds support for arrays by implementing `head`, `tail`, and `print-cell` methods for `array` class. This uses displaced arrays to avoid copying, and (non-destructively) flattens multidimensional arrays. This allows strings to be handled like other sequences: `(take 2 "hello") => "he"`

* Adds `take-all` function which converts a finite sequence to a list by taking all the elements.

* Adds `lazy-sort` function, which only fully sorts the parts of a finite sequence which are asked for. This can be significantly faster than `sort` if only a small part of the sorted list is needed.

* Misc small changes, corrections to comments and formatting. Fix missing brace which prevented fresh load.