### PR TITLE
Use trivial-clock instead of sb-ext in utili.lisp

### DIFF
--- a/lazyseq.asd
+++ b/lazyseq.asd
@@ -5,7 +5,7 @@
   :author "Frederic Peschanski (format nil \"<frederic~Apeschanski~Awork~Agmail~Acom>\" \".\" \".\" \"@\" \".\")" 
   :license "MIT License. See LICENSE."
   :depends-on (:alexandria
-               :cl-trivial-clock)
+               :trivial-clock)
   :in-order-to ((test-op (load-op lazyseq-test)))
   :serial t
   :components ((:file "packages")

--- a/lazyseq.asd
+++ b/lazyseq.asd
@@ -5,7 +5,7 @@
   :author "Frederic Peschanski (format nil \"<frederic~Apeschanski~Awork~Agmail~Acom>\" \".\" \".\" \"@\" \".\")" 
   :license "MIT License. See LICENSE."
   :depends-on (:alexandria
-               )
+               :cl-trivial-clock)
   :in-order-to ((test-op (load-op lazyseq-test)))
   :serial t
   :components ((:file "packages")

--- a/packages.lisp
+++ b/packages.lisp
@@ -1,7 +1,7 @@
 
 (defpackage #:fredokun-utilities
   (:nicknames #:fredo-utils)
-  (:use #:cl)
+  (:use #:cl #:trivial-clock)
   (:export #:*example-enabled*
            #:*example-equal-predicate*
            #:example

--- a/utils.lisp
+++ b/utils.lisp
@@ -149,23 +149,22 @@ from: https://gitlab.com/fredokun/cl-utils
 (defun mk-float-vector (contents)
   (map 'vector #'float contents))
 
-;; from: https://github.com/Shirakumo/trial/blob/a77e7a63ab5b8acdb6939d4c3aef9671d5adcc18/toolkit.lisp#L81
-;; License: Zlib
+;; Use now from trivial-clock: https://github.com/ak-coram/cl-trivial-clock
+;; LICENSE: MTT
 (define-symbol-macro current-time-start
-    (load-time-value (logand (sb-ext:get-time-of-day) (1- (expt 2 32)))))
+    (load-time-value (logand (now) (1- (expt 2 32)))))
 
 (declaim (inline current-time))
 (defun current-time ()
   (declare (optimize speed (safety 0)))
-  #+sbcl (multiple-value-bind (s ms) (sb-ext:get-time-of-day)
-           (let* ((s (logand s (1- (expt 2 62))))
-                  (ms (logand ms (1- (expt 2 62)))))
-             (declare (type (unsigned-byte 62) s ms))
-             (+ (- s current-time-start)
-                (* ms
-                   (coerce 1/1000000 'double-float)))))
-  #-sbcl (* (get-internal-real-time)
-            (coerce (/ internal-time-units-per-second) 'double-float)))
+  (multiple-value-bind (s ns) (now)
+    (let* ((s (logand s (1- (expt 2 62))))
+           (ms (logand ns (1- (expt 2 62)))))
+          (declare (type (unsigned-byte 62) s ms))
+            (+ (- s current-time-start)
+               (* ns (coerce 1/1000000000 'double-float)))))
+    (* (get-internal-real-time)
+       (coerce (/ internal-time-units-per-second) 'double-float)))
 
 
 (defun make-dynarray (&key (contents nil contents-p) (init-size (if contents-p


### PR DESCRIPTION
As mentioned in #9, 
in utils.lisp, the ```current-time``` and ```current-time``` depends on ```sbcl```-only extension function ```sb-ext:get-time-of-day```, it causes Common Lisp implementations such as ```ccl``` and ```ecl``` fail to build/load the package. Here I propose to use [```trivial-clock```](https://github.com/ak-coram/cl-trivial-clock) instead. 